### PR TITLE
Finished expanded views for all three MAMS items

### DIFF
--- a/src/main/java/mams/logic/commands/ApproveCommand.java
+++ b/src/main/java/mams/logic/commands/ApproveCommand.java
@@ -50,8 +50,8 @@ public class ApproveCommand extends Approve {
                     appealToApprove.getAppealDescription(),
                     appealToApprove.getPreviousModule(),
                     appealToApprove.getNewModule(),
-                    appealToApprove.getModule_to_add(),
-                    appealToApprove.getModule_to_drop(),
+                    appealToApprove.getModuleToAdd(),
+                    appealToApprove.getModuleToDrop(),
                     true,
                     "APPROVED",
                     reason);

--- a/src/main/java/mams/logic/commands/ClashAppealCommand.java
+++ b/src/main/java/mams/logic/commands/ClashAppealCommand.java
@@ -91,7 +91,7 @@ public class ClashAppealCommand extends ClashCommand {
      * @return a module object of the requested module in this appeal
      */
     private Module getRequestedModule(Appeal appeal, List<Module> moduleList) throws CommandException {
-        String moduleToAdd = appeal.getModule_to_add();
+        String moduleToAdd = appeal.getModuleToAdd();
         List<Module> modulesToCheckList = moduleList.stream()
                 .filter(m -> m.getModuleCode().equalsIgnoreCase(moduleToAdd)).collect(Collectors.toList());
 

--- a/src/main/java/mams/logic/commands/MassApprove.java
+++ b/src/main/java/mams/logic/commands/MassApprove.java
@@ -42,8 +42,8 @@ public class MassApprove extends Approve {
                                 appealToApprove.getAppealDescription(),
                                 appealToApprove.getPreviousModule(),
                                 appealToApprove.getNewModule(),
-                                appealToApprove.getModule_to_add(),
-                                appealToApprove.getModule_to_drop(),
+                                appealToApprove.getModuleToAdd(),
+                                appealToApprove.getModuleToDrop(),
                                 true,
                                 "APPROVED",
                                 "");

--- a/src/main/java/mams/logic/commands/MassReject.java
+++ b/src/main/java/mams/logic/commands/MassReject.java
@@ -43,8 +43,8 @@ public class MassReject extends Reject {
                                 appealToApprove.getAppealDescription(),
                                 appealToApprove.getPreviousModule(),
                                 appealToApprove.getNewModule(),
-                                appealToApprove.getModule_to_add(),
-                                appealToApprove.getModule_to_drop(),
+                                appealToApprove.getModuleToAdd(),
+                                appealToApprove.getModuleToDrop(),
                                 true,
                                 "REJECTED",
                                 "");

--- a/src/main/java/mams/logic/commands/RejectCommand.java
+++ b/src/main/java/mams/logic/commands/RejectCommand.java
@@ -47,8 +47,8 @@ public class RejectCommand extends Reject {
                     appealToReject.getAppealDescription(),
                     appealToReject.getPreviousModule(),
                     appealToReject.getNewModule(),
-                    appealToReject.getModule_to_add(),
-                    appealToReject.getModule_to_drop(),
+                    appealToReject.getModuleToAdd(),
+                    appealToReject.getModuleToDrop(),
                     true,
                     "REJECTED",
                     reason);

--- a/src/main/java/mams/model/appeal/Appeal.java
+++ b/src/main/java/mams/model/appeal/Appeal.java
@@ -180,11 +180,11 @@ public class Appeal {
         return newModule;
     }
 
-    public String getModule_to_add() {
+    public String getModuleToAdd() {
         return moduleToAdd;
     }
 
-    public String getModule_to_drop() {
+    public String getModuleToDrop() {
         return moduleToDrop;
     }
 
@@ -280,9 +280,9 @@ public class Appeal {
                 .append(" New module: ")
                 .append(getNewModule())
                 .append(" Module to add: ")
-                .append(getModule_to_add())
+                .append(getModuleToAdd())
                 .append(" Module to drop ")
-                .append(getModule_to_drop())
+                .append(getModuleToDrop())
                 .append(" Resolved?:")
                 .append(isResolved())
                 .append(" Result: ")

--- a/src/main/java/mams/model/appeal/AppealContainsKeywordsPredicate.java
+++ b/src/main/java/mams/model/appeal/AppealContainsKeywordsPredicate.java
@@ -28,7 +28,7 @@ public class AppealContainsKeywordsPredicate implements Predicate<Appeal> {
     public boolean test(Appeal appeal) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(appeal.getAppealType(), keyword)
-                        || StringUtil.containsWordIgnoreCase(appeal.getModule_to_add(), keyword)
+                        || StringUtil.containsWordIgnoreCase(appeal.getModuleToAdd(), keyword)
                         || StringUtil.containsWordIgnoreCase(appeal.getStatus(), keyword)
                         || StringUtil.containsWordIgnoreCase(appeal.getAppealId(), keyword));
     }

--- a/src/main/java/mams/storage/JsonAdaptedAppeal.java
+++ b/src/main/java/mams/storage/JsonAdaptedAppeal.java
@@ -75,8 +75,8 @@ public class JsonAdaptedAppeal {
         appealDescription = source.getAppealDescription();
         previousModule = source.getPreviousModule();
         newModule = source.getNewModule();
-        moduleToAdd = source.getModule_to_add();
-        moduleToDrop = source.getModule_to_drop();
+        moduleToAdd = source.getModuleToAdd();
+        moduleToDrop = source.getModuleToDrop();
         resolved = source.isResolved();
         result = source.getResult();
         remark = source.getRemark();

--- a/src/main/java/mams/ui/AppealCard.java
+++ b/src/main/java/mams/ui/AppealCard.java
@@ -10,15 +10,23 @@ import mams.model.appeal.Appeal;
  * An UI component that displays information of an {@code Appeal}.
  */
 public class AppealCard extends UiPart<Region> {
+    public static final String STATUS_APPROVED = "Approved";
+    public static final String STATUS_REJECTED = "Rejected";
+
+    public static final String APPROVED_ICON = "\uD83D\uDC4D";
+    public static final String REJECTED_ICON = "\uD83D\uDC4E";
+
+    public static final String STATUS_RESOLVED = "\u2713" + " Resolved";
+    public static final String STATUS_UNRESOLVED = "\u2718" + " Unresolved";
+
+    public static final String STATUS_BASE_STYLE_CLASS = "prefix-label";
+    public static final String REJECTED_STYLE_CLASS = "prefix_red";
+    public static final String APPROVED_STYLE_CLASS = "prefix_sky_blue";
+
+    public static final String UNRESOLVED_STYLE_CLASS = "prefix_pink";
+    public static final String RESOLVED_STYLE_CLASS = "prefix_green";
 
     private static final String FXML = "AppealListCard.fxml";
-
-    private static final String STATUS_RESOLVED = "\u2713" + " Resolved";
-    private static final String STATUS_UNRESOLVED = "\u2718" + " Unresolved";
-
-    // TODO define own style classes as extensions so that future changes to prefix don't affect this in regression
-    private static final String UNRESOLVED_STYLE_CLASS = "prefix_pink";
-    private static final String RESOLVED_STYLE_CLASS = "prefix_green";
 
     public final Appeal appeal;
 
@@ -35,7 +43,11 @@ public class AppealCard extends UiPart<Region> {
     @FXML
     private Label academicYear;
     @FXML
-    private Label status;
+    private Label approvalIcon;
+    @FXML
+    private Label approvalStatus;
+    @FXML
+    private Label resolvedStatus;
 
     public AppealCard(Appeal appeal, int displayedIndex) {
         super(FXML);
@@ -45,16 +57,34 @@ public class AppealCard extends UiPart<Region> {
         studentId.setText(appeal.getStudentId());
         appealType.setText(appeal.getAppealType());
         academicYear.setText(appeal.getAcademicYear());
-        setStatusDisplay(status, appeal.isResolved());
+        // TODO change once aaron implements getter method
+        setApprovalStatusDisplay(approvalIcon, approvalStatus, appeal.isResolved(),
+                appeal.getResult().equals("APPROVED"));
+        setResolvedStatusDisplay(resolvedStatus, appeal.isResolved());
     }
 
-    private static void setStatusDisplay(Label status, boolean isResolved) {
+    public static void setResolvedStatusDisplay(Label resolvedStatus, boolean isResolved) {
         if (isResolved) {
-            status.setText(STATUS_RESOLVED);
-            status.getStyleClass().add(RESOLVED_STYLE_CLASS);
+            resolvedStatus.setText(STATUS_RESOLVED);
+            resolvedStatus.getStyleClass().add(RESOLVED_STYLE_CLASS);
         } else {
-            status.setText(STATUS_UNRESOLVED);
-            status.getStyleClass().add(UNRESOLVED_STYLE_CLASS);
+            resolvedStatus.setText(STATUS_UNRESOLVED);
+            resolvedStatus.getStyleClass().add(UNRESOLVED_STYLE_CLASS);
+        }
+    }
+
+    public static void setApprovalStatusDisplay(Label approvalIcon, Label approvalStatus,
+                                                boolean isResolved, boolean isApproved) {
+        if (isResolved) {
+            if (isApproved) {
+                approvalIcon.setText(APPROVED_ICON);
+                approvalStatus.setText(STATUS_APPROVED);
+                approvalStatus.getStyleClass().addAll(STATUS_BASE_STYLE_CLASS, APPROVED_STYLE_CLASS);
+            } else {
+                approvalIcon.setText(REJECTED_ICON);
+                approvalStatus.setText(STATUS_REJECTED);
+                approvalStatus.getStyleClass().addAll(STATUS_BASE_STYLE_CLASS, REJECTED_STYLE_CLASS);
+            }
         }
     }
 

--- a/src/main/java/mams/ui/AppealListPanel.java
+++ b/src/main/java/mams/ui/AppealListPanel.java
@@ -17,11 +17,14 @@ public class AppealListPanel extends UiPart<Region> {
     private static final String FXML = "ItemListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(AppealListPanel.class);
 
+    private final ObservableList<Appeal> appealList;
+
     @FXML
     private ListView<Appeal> itemListView;
 
     public AppealListPanel(ObservableList<Appeal> appealList) {
         super(FXML);
+        this.appealList = appealList;
         itemListView.setItems(appealList);
         itemListView.setCellFactory(listView -> new AppealListViewCell());
     }
@@ -37,6 +40,8 @@ public class AppealListPanel extends UiPart<Region> {
             if (empty || appeal == null) {
                 setGraphic(null);
                 setText(null);
+            } else if (appealList.size() == 1) {
+                setGraphic(new ExpandedAppealCard(appeal).getRoot());
             } else {
                 setGraphic(new AppealCard(appeal, getIndex() + 1).getRoot());
             }

--- a/src/main/java/mams/ui/ExpandedAppealCard.java
+++ b/src/main/java/mams/ui/ExpandedAppealCard.java
@@ -1,0 +1,86 @@
+package mams.ui;
+
+import static mams.ui.AppealCard.setApprovalStatusDisplay;
+import static mams.ui.AppealCard.setResolvedStatusDisplay;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import mams.model.appeal.Appeal;
+
+/**
+ * A UI component that displays the full expanded information of an {@code Appeal}.
+ * Does not inherit from {@code AppealCard} as it uses a different FXML file -
+ * this is to ensure minimal complications in future development, where fx:id's
+ * and layouts of various components in the FXML file of {@code ExpandedAppealCard}
+ * may diverge from the FXML file used in the {@code AppealCard}. Furthermore,
+ * the {@code id} is also no longer used in the expanded view.
+ */
+public class ExpandedAppealCard extends UiPart<Region> {
+
+    public static final String NOT_APPLICABLE = "N/A";
+
+    private static final String FXML = "ExpandedAppealListCard.fxml";
+
+    public final Appeal appeal;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label appealId;
+    @FXML
+    private Label appealType;
+    @FXML
+    private Label studentId;
+    @FXML
+    private Label academicYear;
+    @FXML
+    private Label requestedWorkload;
+    @FXML
+    private Label moduleToDrop;
+    @FXML
+    private Label requestedModule;
+    @FXML
+    private Label appealDescription;
+    @FXML
+    private Label approvalIcon;
+    @FXML
+    private Label approvalStatus;
+    @FXML
+    private Label resolvedStatus;
+
+    public ExpandedAppealCard(Appeal appeal) {
+        super(FXML);
+        this.appeal = appeal;
+        appealId.setText(appeal.getAppealId());
+        studentId.setText(appeal.getStudentId());
+        appealType.setText(appeal.getAppealType());
+        academicYear.setText(appeal.getAcademicYear());
+        requestedWorkload.setText(Integer.toString(appeal.getStudentWorkload()));
+        moduleToDrop.setText(appeal.getModuleToDrop());
+        requestedModule.setText(appeal.getModuleToAdd());
+        appealDescription.setText(appeal.getAppealDescription());
+        setResolvedStatusDisplay(resolvedStatus, appeal.isResolved());
+        // TODO change once aaron implements getter method
+        setApprovalStatusDisplay(approvalIcon, approvalStatus, appeal.isResolved(),
+                appeal.getResult().equals("APPROVED"));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AppealCard)) {
+            return false;
+        }
+
+        // state check
+        AppealCard card = (AppealCard) other;
+        return appeal.equals(card.appeal);
+    }
+}

--- a/src/main/java/mams/ui/ExpandedModuleCard.java
+++ b/src/main/java/mams/ui/ExpandedModuleCard.java
@@ -1,0 +1,94 @@
+package mams.ui;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import mams.model.module.Module;
+
+/**
+ * A UI component that displays the full expanded information of an {@code Module}.
+ * Does not inherit from {@code ModuleCard} as it uses a different FXML file -
+ * this is to ensure minimal complications in future development, where fx:id's
+ * and layouts of various components in the FXML file of {@code ExpandedModuleCard}
+ * may diverge from the FXML file used in the {@code ModuleCard}. Furthermore,
+ * the {@code id} is also no longer used in the expanded view.
+ */
+public class ExpandedModuleCard extends UiPart<Region> {
+
+    private static final String FXML = "ExpandedModuleListCard.fxml";
+    public final Module module;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label moduleCode;
+    @FXML
+    private Label moduleName;
+    @FXML
+    private Label lecturerName;
+    @FXML
+    private Label timeSlot;
+    @FXML
+    private Label enrolment;
+    @FXML
+    private Label quota;
+    @FXML
+    private ProgressBar quotaBar;
+    @FXML
+    private Label moduleDescription;
+    @FXML
+    private Label studentsEnrolled;
+
+    public ExpandedModuleCard(Module module) {
+        super(FXML);
+        this.module = module;
+        moduleCode.setText(module.getModuleCode());
+        moduleName.setText(module.getModuleName());
+        lecturerName.setText(module.getLecturerName());
+        timeSlot.setText(module.getModuleTimeTableToString());
+        enrolment.setText(Integer.toString(module.getCurrentEnrolment()));
+        quota.setText(Integer.toString(module.getQuota()));
+        setEnrolmentProgressBar();
+        moduleDescription.setText(module.getModuleDescription());
+        studentsEnrolled.setText(formatStudentEnrolmentToText());
+    }
+
+    private void setEnrolmentProgressBar() {
+        double percentageFilled = (double) module.getCurrentEnrolment() / module.getQuota();
+        quotaBar.setProgress(percentageFilled);
+    }
+
+    /**
+     * Formats the list of student IDs contained in {@code Module} to a {@code String} object,
+     * with one student ID on each line, sorted by alpha-numeric order.
+     * @return formatted text of student IDs.
+     */
+    private String formatStudentEnrolmentToText () {
+        return module.getStudents().stream()
+                .sorted(Comparator.comparing(student -> student.tagName))
+                .map(student -> student.tagName)
+                .collect(Collectors.joining("\n"));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ModuleCard)) {
+            return false;
+        }
+
+        // state check
+        ModuleCard card = (ModuleCard) other;
+        return module.equals(card.module);
+    }
+}

--- a/src/main/java/mams/ui/ExpandedStudentCard.java
+++ b/src/main/java/mams/ui/ExpandedStudentCard.java
@@ -1,0 +1,106 @@
+package mams.ui;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import mams.model.student.Student;
+
+/**
+ * A UI component that displays the full expanded information of an {@code Student}.
+ * Does not inherit from {@code StudentCard} as it uses a different FXML file -
+ * this is to ensure minimal complications in future development, where fx:id's
+ * and layouts of various components in the FXML file of {@code ExpandedStudentCard}
+ * may diverge from the FXML file used in the {@code StudentCard}. Furthermore,
+ * the {@code id} is also no longer used in the expanded view.
+ */
+public class ExpandedStudentCard extends UiPart<Region> {
+
+    private static final String FXML = "ExpandedStudentListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Student student;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label credits;
+    @FXML
+    private Label matricId;
+    @FXML
+    private Label currentMods;
+    @FXML
+    private Label currentAppeals;
+    @FXML
+    private FlowPane appealTags;
+    @FXML
+    private Label numberOfMods;
+
+    public ExpandedStudentCard(Student student) {
+        super(FXML);
+        this.student = student;
+        name.setText(student.getName().fullName);
+        credits.setText(student.getCredits().value);
+        matricId.setText(student.getMatricId().value);
+        currentMods.setText(formatCurrentModuleListToText());
+        currentAppeals.setText(formatCurrentAppealListToText());
+        numberOfMods.setText(Integer.toString(student.getNumberOfMods()));
+        student.getCurrentAppeals().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> appealTags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    /**
+     * Formats the list of {@code Module} codes contained in {@code Student} to a {@code String} object,
+     * with one module code on each line, sorted by alpha-numeric order.
+     * @return formatted text of module codes.
+     */
+    private String formatCurrentModuleListToText () {
+        return student.getCurrentModules().stream()
+                .sorted(Comparator.comparing(module -> module.tagName))
+                .map(module -> module.tagName)
+                .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Formats the list of {@code Appeal} IDs contained in {@code Student} to a {@code String} object,
+     * with one appeal ID on each line, sorted by alpha-numeric order.
+     * @return formatted text of appeal IDs.
+     */
+    private String formatCurrentAppealListToText () {
+        return student.getCurrentAppeals().stream()
+                .sorted(Comparator.comparing(appeal -> appeal.tagName))
+                .map(appeal -> appeal.tagName)
+                .collect(Collectors.joining("\n"));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StudentCard)) {
+            return false;
+        }
+
+        // state check
+        StudentCard card = (StudentCard) other;
+        return student.equals(card.student);
+    }
+}

--- a/src/main/java/mams/ui/ModuleCard.java
+++ b/src/main/java/mams/ui/ModuleCard.java
@@ -34,8 +34,6 @@ public class ModuleCard extends UiPart<Region> {
     @FXML
     private ProgressBar quotaBar;
 
-    // TODO add more fields for module display card
-
     public ModuleCard(Module module, int displayedIndex) {
         super(FXML);
         this.module = module;

--- a/src/main/java/mams/ui/ModuleListPanel.java
+++ b/src/main/java/mams/ui/ModuleListPanel.java
@@ -17,11 +17,14 @@ public class ModuleListPanel extends UiPart<Region> {
     private static final String FXML = "ItemListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(ModuleListPanel.class);
 
+    private final ObservableList<Module> moduleList;
+
     @FXML
     private ListView<Module> itemListView;
 
     public ModuleListPanel(ObservableList<Module> moduleList) {
         super(FXML);
+        this.moduleList = moduleList;
         itemListView.setItems(moduleList);
         itemListView.setCellFactory(listView -> new ModuleListViewCell());
     }
@@ -37,6 +40,8 @@ public class ModuleListPanel extends UiPart<Region> {
             if (empty || module == null) {
                 setGraphic(null);
                 setText(null);
+            } else if (moduleList.size() == 1) {
+                setGraphic(new ExpandedModuleCard(module).getRoot());
             } else {
                 setGraphic(new ModuleCard(module, getIndex() + 1).getRoot());
             }

--- a/src/main/java/mams/ui/StudentCard.java
+++ b/src/main/java/mams/ui/StudentCard.java
@@ -37,9 +37,9 @@ public class StudentCard extends UiPart<Region> {
     @FXML
     private Label matricId;
     @FXML
-    private Label prevMods;
+    private Label numberOfMods;
     @FXML
-    private FlowPane tags;
+    private FlowPane appealTags;
 
     public StudentCard(Student student, int displayedIndex) {
         super(FXML);
@@ -48,10 +48,10 @@ public class StudentCard extends UiPart<Region> {
         name.setText(student.getName().fullName);
         credits.setText(student.getCredits().value);
         matricId.setText(student.getMatricId().value);
-        prevMods.setText(student.getPrevMods().value);
+        numberOfMods.setText(Integer.toString(student.getNumberOfMods()));
         student.getCurrentAppeals().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .forEach(tag -> appealTags.getChildren().add(new Label(tag.tagName)));
     }
 
     @Override

--- a/src/main/java/mams/ui/StudentListPanel.java
+++ b/src/main/java/mams/ui/StudentListPanel.java
@@ -40,6 +40,8 @@ public class StudentListPanel extends UiPart<Region> {
             if (empty || student == null) {
                 setGraphic(null);
                 setText(null);
+            } else if (studentList.size() == 1) {
+                setGraphic(new ExpandedStudentCard(student).getRoot());
             } else {
                 setGraphic(new StudentCard(student, getIndex() + 1).getRoot());
             }

--- a/src/main/resources/view/AppealListCard.fxml
+++ b/src/main/resources/view/AppealListCard.fxml
@@ -27,7 +27,9 @@
                 </Label>
                 <Label fx:id="appealId" text="\$appealId" styleClass="cell_big_label" />
                 <Pane HBox.hgrow="ALWAYS"/>
-                <Label fx:id="status" styleClass="prefix-label" text="\%status" alignment="CENTER_RIGHT"/>
+                <Label fx:id="approvalIcon" alignment="CENTER_RIGHT" />
+                <Label fx:id="approvalStatus" alignment="CENTER_RIGHT" />
+                <Label fx:id="resolvedStatus" styleClass="prefix-label" text="\%resolvedStatus" alignment="CENTER_RIGHT"/>
             </HBox>
             <HBox spacing="3">
                 <padding>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -123,15 +123,24 @@
     -fx-text-fill: white;
 }
 
+.label.cell_small_label {
+    -fx-font-family: "Roboto Mono for Powerline";
+    -fx-font-size: 13px;
+    -fx-tile-alignment: CENTER;
+}
+
+.cell_small_label.description_text {
+    -fx-wrap-text: true;
+}
+
 .label.cell_big_label {
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 16px;
 }
 
-.label.cell_small_label {
-    -fx-font-family: "Roboto Mono for Powerline";
-    -fx-font-size: 13px;
-    -fx-tile-alignment: CENTER;
+.label.cell_bigger_label {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 25px;
 }
 
 .cell_small_label.green-text-label {
@@ -140,6 +149,38 @@
 
 .cell_small_label.yellow-text-label {
     -fx-text-fill: #EFF88B;
+}
+
+.cell_big_label.green-text-label {
+    -fx-text-fill: #4FF77A;
+}
+
+.cell_big_label.yellow-text-label {
+    -fx-text-fill: #EFF88B;
+}
+
+.cell_big_label.orange-text-label {
+    -fx-text-fill: #FEB86C;
+}
+
+.cell_big_label.pink-text-label {
+    -fx-text-fill: #FA77C3;
+}
+
+.cell_bigger_label.green-text-label {
+    -fx-text-fill: #4FF77A;
+}
+
+.cell_bigger_label.yellow-text-label {
+    -fx-text-fill: #EFF88B;
+}
+
+.cell_bigger_label.blue-text-label {
+    -fx-text-fill: #86ACC9;
+}
+
+.cell_bigger_label.pink-text-label {
+    -fx-text-fill: #FA77C3;
 }
 
 .label.prefix-label {

--- a/src/main/resources/view/ExpandedAppealListCard.fxml
+++ b/src/main/resources/view/ExpandedAppealListCard.fxml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<?import javafx.scene.layout.Pane?>
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="TOP_LEFT" minHeight="600" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="appealId" text="\$appealId" styleClass="cell_bigger_label" />
+                <Pane HBox.hgrow="ALWAYS"/>
+                <Label fx:id="approvalIcon" alignment="CENTER_RIGHT" />
+                <Label fx:id="approvalStatus" alignment="CENTER_RIGHT" />
+                <Label fx:id="resolvedStatus" styleClass="prefix-label" text="\%resolvedStatus" alignment="CENTER_RIGHT"/>
+            </HBox>
+            <Label fx:id="appealType" styleClass="cell_bigger_label, pink-text-label" text="\$appealType" />
+
+            <Label minHeight="20" />
+
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="studentIdPrefix" styleClass="prefix-label, prefix_yellow" text="Requested By" />
+                <Label fx:id="studentId" styleClass="cell_small_label" text="\$studentId" />
+            </HBox>
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="academicYearPrefix" styleClass="prefix-label, prefix_yellow" text="Academic Year" />
+                <Label fx:id="academicYear" styleClass="cell_small_label" text="\$academicYear" />
+            </HBox>
+
+            <Label minHeight="20" />
+
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="requestedWorkloadPrefix" styleClass="prefix-label, prefix_orange" text="Requested Workload" />
+                <Label fx:id="requestedWorkload" styleClass="cell_small_label" text="N/A" />
+            </HBox>
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="moduleToDropPrefix" styleClass="prefix-label, prefix_orange" text="Module to Drop" />
+                <Label fx:id="moduleToDrop" styleClass="cell_small_label" text="N/A" />
+            </HBox>
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="requestedModulePrefix" styleClass="prefix-label, prefix_orange" text="Requested Module" />
+                <Label fx:id="requestedModule" styleClass="cell_small_label" text="N/A" />
+            </HBox>
+
+            <Label minHeight="20" />
+
+            <Label fx:id="appealDescriptionPrefix" styleClass="cell_big_label, orange-text-label" text="Student Reason:"/>
+            <Label fx:id="appealDescription" styleClass="cell_small_label, description_text" text="\$appealDescription" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/ExpandedModuleListCard.fxml
+++ b/src/main/resources/view/ExpandedModuleListCard.fxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<?import javafx.scene.control.ProgressBar?>
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="TOP_LEFT" minHeight="600" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <Label fx:id="moduleCode" text="\$first" styleClass="cell_bigger_label" />
+            <Label fx:id="moduleName" styleClass="cell_bigger_label, green-text-label" text="\$moduleName" />
+
+            <Label minHeight="20" />
+            <Label fx:id="timeSlot" styleClass="cell_small_label, yellow-text-label" text="\$timeSlot" />
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="lecturerNamePrefix" styleClass="prefix-label, prefix_sky_blue" text="Coordinator" />
+                <Label fx:id="lecturerName" styleClass="cell_small_label" text="\$lecturerName" />
+            </HBox>
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="quotaPrefix" styleClass="prefix-label, prefix_sky_blue" text="Quota" />
+                <ProgressBar fx:id="quotaBar" />
+                <Label fx:id="enrolment" styleClass="cell_small_label" text="\$enrolment" />
+                <Label styleClass="cell_small_label" text="/" />
+                <Label fx:id="quota" styleClass="cell_small_label" text="\$quota" />
+            </HBox>
+            <Label minHeight="20" />
+
+            <Label fx:id="moduleDescriptionPrefix" styleClass="cell_big_label, yellow-text-label" text="Module Description:" />
+            <Label fx:id="moduleDescription" styleClass="cell_small_label, description_text" text="\$moduleDescription" />
+            <Label minHeight="20" />
+
+            <Label fx:id="studentsEnrolledPrefix" styleClass="cell_big_label, yellow-text-label" text="Students Enrolled: " />
+            <Label fx:id="studentsEnrolled" styleClass="cell_small_label" text="\$studentsEnrolled" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/ExpandedStudentListCard.fxml
+++ b/src/main/resources/view/ExpandedStudentListCard.fxml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="TOP_LEFT" minHeight="600" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <Label fx:id="matricId" styleClass="cell_bigger_label" text="\$matricId" />
+            <Label fx:id="name" text="\$first" styleClass="cell_bigger_label, blue-text-label" />
+            <FlowPane fx:id="appealTags" />
+
+            <Label minHeight="20" />
+
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="creditsPrefix" styleClass="prefix-label,  prefix_purple" text="Current Workload" />
+                <Label fx:id="credits" styleClass="cell_small_label" text="\$credits" />
+                <Label fx:id="creditsSuffix" styleClass="cell_small_label" text=" MC(s)" />
+            </HBox>
+            <HBox spacing="3">
+                <padding>
+                    <Insets top="1" bottom="1" />
+                </padding>
+                <Label fx:id="numberOfModsPrefix" styleClass="prefix-label,  prefix_purple" text="Currently Taking" />
+                <Label fx:id="numberOfMods" styleClass="cell_small_label" text="\$numberOfMods" />
+                <Label fx:id="numberOfModsSuffix" styleClass="cell_small_label" text=" module(s)" />
+            </HBox>
+
+            <Label minHeight="20" />
+
+            <Label fx:id="currentModsPrefix" styleClass="cell_big_label, pink-text-label" text="Modules Currently Taking:" />
+            <Label fx:id="currentMods" styleClass="cell_small_label, description_text" text="\$currentMods" />
+
+            <Label minHeight="20" />
+
+            <Label fx:id="currentAppealsPrefix" styleClass="cell_big_label, pink-text-label" text="Appeals:" />
+            <Label fx:id="currentAppeals" styleClass="cell_small_label, description_text" text="\$appeals" />
+
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -27,27 +27,28 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="tags" />
-      <HBox spacing="3">
+      <FlowPane fx:id="appealTags" />
+      <HBox spacing="3" alignment="CENTER_LEFT">
         <padding>
           <Insets top="1" bottom="1" />
         </padding>
         <Label fx:id="matricPrefix" styleClass="prefix-label, prefix_purple" text="Matric. No" />
         <Label fx:id="matricId" styleClass="cell_small_label" text="\$matricId" />
       </HBox>
-      <HBox spacing="3">
+      <HBox spacing="3" alignment="CENTER_LEFT">
         <padding>
           <Insets top="1" bottom="1" />
         </padding>
         <Label fx:id="creditsPrefix" styleClass="prefix-label,  prefix_purple" text="Credits" />
         <Label fx:id="credits" styleClass="cell_small_label" text="\$credits" />
       </HBox>
-      <HBox spacing="3">
+      <HBox spacing="3" alignment="CENTER_LEFT">
         <padding>
           <Insets top="1" bottom="1" />
         </padding>
-        <Label fx:id="prevModsPrefix" styleClass="prefix-label, prefix_purple" text="Modules Taken" />
-        <Label fx:id="prevMods" styleClass="cell_small_label" text="\$prevMods" />
+        <Label fx:id="currentModulesPrefix" styleClass="prefix-label,  prefix_purple" text="Currently Taking" />
+        <Label fx:id="numberOfMods" styleClass="cell_small_label" text="\$numberOfMods" />
+        <Label fx:id="numberOfModsSuffix" styleClass="cell_small_label" text=" module(s)" />
       </HBox>
     </VBox>
   </GridPane>

--- a/src/test/java/mams/storage/JsonAdaptedAppealTest.java
+++ b/src/test/java/mams/storage/JsonAdaptedAppealTest.java
@@ -22,7 +22,7 @@ public class JsonAdaptedAppealTest {
     private static final String VALID_ACADEMIC_YEAR = TypicalAppeals.APPEAL2.getAcademicYear();
     private static final int VALID_WORKLOAD = TypicalAppeals.APPEAL2.getStudentWorkload();
     private static final String VALID_DESCRIPTION = TypicalAppeals.APPEAL2.getAppealDescription();
-    private static final String VALID_MODULES = TypicalAppeals.APPEAL2.getModule_to_drop();
+    private static final String VALID_MODULES = TypicalAppeals.APPEAL2.getModuleToDrop();
     private static final boolean VALID_IS_RESOLVED = TypicalAppeals.APPEAL2.isResolved();
     private static final String VALID_REMARK = TypicalAppeals.APPEAL2.getRemark();
 


### PR DESCRIPTION
- All MAMS items now have expanded view versions on the GUI
- Cards will automatically be expanded when they're the only result on the list

Notes:
- For now, lists of data within an expanded view (eg. list of students in an `ExpandedModuleCard`, or list of modules a student is taking in an ``ExpandedStudentCard`) only show the list of ID codes. If data inside `mams.json` is made to be fully authentic (ie. all student IDs refer to a real student) then it will be possible to display extra details like names as well.

close #42 #43 