### PR TITLE
Getter methods to fix filtered lists issues in some commands

### DIFF
--- a/src/main/java/mams/model/Model.java
+++ b/src/main/java/mams/model/Model.java
@@ -1,6 +1,7 @@
 package mams.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -144,6 +145,33 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered appeal list */
     ObservableList<Appeal> getFilteredAppealList();
+
+    /** Returns an unmodifiable view of the full appeal list in MAMS */
+    ObservableList<Appeal> getFullAppealList();
+
+    /** Returns an unmodifiable view of the full module list in MAMS */
+    ObservableList<Module> getFullModuleList();
+
+    /** Returns an unmodifiable view of the full student list in MAMS */
+    ObservableList<Student> getFullStudentList();
+
+    /**
+     * Returns an {@code Optional} containing the appeal in MAMS matching the given id.
+     * If no appeal in MAMS matches the given id, then this returns Optional.empty()
+     * Note: the search is performed on the global list, not the filtered list.
+     * @param id Appeal id to be queried against
+     * @return Optional.of(Appeal) if found, else Optional.empty()
+     */
+    public Optional<Appeal> getAppealEqualsToId(String id);
+
+    /**
+     * Returns an {@code Optional} containing the module in MAMS matching the given id.
+     * If no module in MAMS matches the given id, then this returns Optional.empty()
+     * Note: the search is performed on the global list, not the filtered list.
+     * @param id module id to be queried against
+     * @return Optional.of(Module) if found, else Optional.empty()
+     */
+    public Optional<Module> getModuleEqualsToId(String id);
 
     /**
      * Updates the filter of the filtered student list to filter by the given {@code predicate}.

--- a/src/main/java/mams/model/ModelManager.java
+++ b/src/main/java/mams/model/ModelManager.java
@@ -3,8 +3,11 @@ package mams.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -176,7 +179,7 @@ public class ModelManager implements Model {
         mams.setAppeal(target, editedAppeal);
     }
 
-    //=========== Filtered Student List Accessors =============================================================
+    //=========== Filtered List Accessors =============================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Student} backed by the internal list of
@@ -213,6 +216,47 @@ public class ModelManager implements Model {
     public void updateFilteredAppealList(Predicate<Appeal> predicate) {
         requireNonNull(predicate);
         filteredAppeals.setPredicate(predicate);
+    }
+
+
+    //=========== Full List Accessors =============================================================
+
+    /** Returns an unmodifiable view of the full appeal list in MAMS */
+    public ObservableList<Appeal> getFullAppealList() {
+        return mams.getAppealList();
+    }
+
+    /** Returns an unmodifiable view of the full module list in MAMS */
+    public ObservableList<Module> getFullModuleList() {
+        return mams.getModuleList();
+    }
+
+    /** Returns an unmodifiable view of the full student list in MAMS */
+    public ObservableList<Student> getFullStudentList() {
+        return mams.getStudentList();
+    }
+
+    //=========== Individual Items Accessors =============================================================
+    @Override
+    public Optional<Appeal> getAppealEqualsToId(String id) {
+        List<Appeal> resultList = getFullAppealList().stream()
+                .filter(a -> a.getAppealId().equalsIgnoreCase(id))
+                .collect(Collectors.toList());
+        assert resultList.size() < 2 : "Assertion Error: Appeal List in MAMS has duplicate IDs";
+        return (resultList.isEmpty())
+                ? Optional.empty()
+                : Optional.of(resultList.get(0));
+    }
+
+    @Override
+    public Optional<Module> getModuleEqualsToId(String id) {
+        List<Module> resultList = getFullModuleList().stream()
+                .filter(m -> m.getModuleCode().equalsIgnoreCase(id))
+                .collect(Collectors.toList());
+        assert resultList.size() < 2 : "Assertion Error: Module List in MAMS has duplicate IDs";
+        return (resultList.isEmpty())
+                ? Optional.empty()
+                : Optional.of(resultList.get(0));
     }
 
     @Override


### PR DESCRIPTION
- Implemented global lists getters (unmodifiable view) in `Model` to fix various issues in commands 
- Implemented the ability to retrieve individual appeals and modules matching a given ID. Students is not yet implemented since I'm not sure whether you guys are searching by String or MatricId, but it's very easily copied over.