### PR TITLE
Fixed HistoryWindow re-opening focus loss issue. Made list and histor…

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -27,7 +27,16 @@ The Module Appeal Management System (MAMS) is a desktop app that aims to combine
 .  Copy the file to the folder you want to use as the home folder for The Module Appeal Management System (MAMS).
 . **Important**: Unzip `data.zip`. Inside, there should be a folder containing `mams.json`, ie. `data/mams.json`.
 Copy the `data` folder containing `mams.json` to the same directory as `mams.jar`. Due to the special nature of
-app, users are specifically restricted from deleting/adding data entries.
+app, users are specifically restricted from deleting/adding data entries. Note that certain un-archiver tools
+may automatically create a new parent `data/` folder around the zipped `data/` folder. Should that happen, please only
+move the inner `data/` folder containing `mams.json` to the target directory. In any case, the resulting
+folder structure should look a little like the below:
+
+  .
+  ├── mams.jar
+  └── data/
+      └── mams.json
+
 .  Double-click the file to start the app. The GUI should appear in a few seconds..
 +
 image::Ui.png[width="790"]
@@ -56,7 +65,6 @@ A module is uniquely identified by a COURSE_PREFIX (eg. `CS` for Computer Scienc
 * Items enclosed by square brackets are optional, eg. `list [-a] [-m] [-s]` can be used as `list` or `list -s`.
 * Any item that is followed by an ellipsis (`...`) can be used multiple times including zero eg. `[m/PARAMETER]...` can be supplied as `m/PARAMETER` or `m/PARAMETER1 m/PARAMETER2`
 * Arguments within square brackets can be supplied in any order.
-* There
 * Tags will often be used in the command to specify the targeted list for the command. Certain commands allow operations on multiple lists.
 ** `a/` : prefix for the `Appeal List`
 ** `m/` : prefix for the `Module List`

--- a/src/main/java/mams/logic/parser/HistoryCommandParser.java
+++ b/src/main/java/mams/logic/parser/HistoryCommandParser.java
@@ -17,7 +17,7 @@ public class HistoryCommandParser implements Parser<HistoryCommand> {
     public static final Option OPTION_HIDE_OUTPUT = new Option("o");
     public static final Option OPTION_HIDE_UNSUCCESSFUL = new Option("s");
 
-    public static final String MESSAGE_OPTIONS_NOT_RECOGNIZED = "Invalid options: %1$s";
+    public static final String MESSAGE_OPTIONS_NOT_RECOGNIZED = "Invalid parameters: %1$s";
 
     /**
      * Parses the given {@code String} of arguments in the context of the HistoryCommand
@@ -27,9 +27,9 @@ public class HistoryCommandParser implements Parser<HistoryCommand> {
     @Override
     public HistoryCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        OptionsSet optionsSet = OptionsTokenizer.tokenize(args);
+        verifyNoUnrecognizedArguments(args, OPTION_HIDE_OUTPUT, OPTION_HIDE_UNSUCCESSFUL);
 
-        verifyNoUnrecognizedOptions(optionsSet, OPTION_HIDE_OUTPUT, OPTION_HIDE_UNSUCCESSFUL);
+        OptionsSet optionsSet = OptionsTokenizer.tokenize(args);
 
         // determine whether user has decided to filter successful or unsuccessful command out
         HistoryFilterSettings displayOptions;
@@ -55,6 +55,25 @@ public class HistoryCommandParser implements Parser<HistoryCommand> {
                     .collect(Collectors.joining(" "));
             throw new ParseException(String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, unrecognizedOptionsAsString)
                     + " \n" + HistoryCommand.MESSAGE_USAGE);
+        }
+    }
+
+    /**
+     * Throws a ParseException if there are any arguments in {@code args} that do not match the format of
+     * any {@code Option} in the supplied {@code options} array. This is a convenient wrapper around the
+     * {@link OptionsTokenizer#getUnrecognizedArguments(String, String...)} method to throw errors specific to
+     * HistoryCommand.
+     * @param args String to be parsed
+     * @param recognized Array of {@code Option} that are deemed acceptable
+     * @throws ParseException if args contain any arguments other than those in {@code recognized}
+     */
+    private void verifyNoUnrecognizedArguments(String args, Option... recognized) throws ParseException {
+        List<String> unrecognized = OptionsTokenizer.getUnrecognizedArguments(args, recognized);
+        if (!unrecognized.isEmpty()) {
+            String unrecognizedParamsAsSingleString = String.join(" ", unrecognized).trim();
+            throw new ParseException(String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED,
+                    unrecognizedParamsAsSingleString)
+                    + "\n" + HistoryCommand.MESSAGE_USAGE);
         }
     }
 }

--- a/src/main/java/mams/logic/parser/ListCommandParser.java
+++ b/src/main/java/mams/logic/parser/ListCommandParser.java
@@ -17,7 +17,7 @@ import mams.logic.parser.exceptions.ParseException;
  */
 public class ListCommandParser implements Parser<ListCommand> {
 
-    public static final String OPTIONS_NOT_RECOGNIZED = "Invalid options: %1$s";
+    public static final String MESSAGE_OPTIONS_NOT_RECOGNIZED = "Invalid parameters: %1$s";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ListCommand
@@ -32,9 +32,8 @@ public class ListCommandParser implements Parser<ListCommand> {
         boolean showAppeals = false;
         boolean showAll;
 
+        verifyNoUnrecognizedArguments(args, OPTION_APPEAL, OPTION_MODULE, OPTION_STUDENT);
         OptionsSet optionsSet = OptionsTokenizer.tokenize(args);
-
-        verifyNoUnrecognizedOptions(optionsSet, OPTION_APPEAL, OPTION_MODULE, OPTION_STUDENT);
 
         // if no prefixes were specified, default to list all items.
         showAll = optionsSet.areAllTheseOptionAbsent(OPTION_APPEAL, OPTION_MODULE, OPTION_STUDENT);
@@ -63,8 +62,27 @@ public class ListCommandParser implements Parser<ListCommand> {
         if (!unrecognizedOptions.isEmpty()) {
             String unrecognizedOptionsAsString = unrecognizedOptions.stream().map(Option::toString)
                     .collect(Collectors.joining(" "));
-            throw new ParseException(String.format(OPTIONS_NOT_RECOGNIZED, unrecognizedOptionsAsString)
+            throw new ParseException(String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, unrecognizedOptionsAsString)
                     + " \n" + ListCommand.MESSAGE_USAGE);
+        }
+    }
+
+    /**
+     * Throws a ParseException if there are any arguments in {@code args} that do not match the format of
+     * any {@code Option} in the supplied {@code options} array. This is a convenient wrapper around the
+     * {@link OptionsTokenizer#getUnrecognizedArguments(String, String...)} method to throw error messages specific
+     * to ListCommand.
+     * @param args String to be parsed
+     * @param recognized Array of {@code Option} that are deemed acceptable
+     * @throws ParseException if args contain any arguments other than those in {@code recognized}
+     */
+    private void verifyNoUnrecognizedArguments(String args, Option... recognized) throws ParseException {
+        List<String> unrecognized = OptionsTokenizer.getUnrecognizedArguments(args, recognized);
+        if (!unrecognized.isEmpty()) {
+            String unrecognizedParamsAsSingleString = String.join(" ", unrecognized).trim();
+            throw new ParseException(String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED,
+                    unrecognizedParamsAsSingleString)
+                    + "\n" + ListCommand.MESSAGE_USAGE);
         }
     }
 }

--- a/src/main/java/mams/logic/parser/OptionsTokenizer.java
+++ b/src/main/java/mams/logic/parser/OptionsTokenizer.java
@@ -6,16 +6,22 @@ import static mams.commons.util.CollectionUtil.requireAllNonNull;
 import static mams.logic.parser.Option.isValidOption;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Simple utility class for tokenize-ing an input String to check for presence
- * of options. Unlike ArgumentTokenizer, which takes any characters after the given prefix
+ * Simple utility class to tokenize an input String, and subsequently check for presence
+ * of {@code Option} objects. Unlike ArgumentTokenizer, which takes any characters after the given prefix
  * as arguments, OptionsTokenizer requires that each option be preceded by a dash, and must
- * be strictly space delimited (or occurs at the end of the String).
+ * be strictly space delimited (or occurs at the end of the String). In other words, this should be used for
+ * simpler command formats that do not require taking in of values, and only need to check for the presence of flags
+ * (represented as {@code Option}), as it provides a much cleaner and readable API in such contexts,
+ * without the need for obfuscating calls to {@code Optional} for fetching of values
+ * just to check for the presence of an option. Since it is optimized for a simpler, space-delimited format,
+ * it also provides specialized functions to fetch unrecognized space-delimited arguments.
  */
 public class OptionsTokenizer {
 
@@ -50,11 +56,27 @@ public class OptionsTokenizer {
         List<String> unrecognizedList = new ArrayList<>();
         String[] tokenizedArgs = getTokenizedBySpaceAndTrimmed(args);
         for (String arg: tokenizedArgs) {
-            if (!recognizedSet.contains(arg)) {
+            if (!arg.isBlank() && !recognizedSet.contains(arg)) {
                 unrecognizedList.add(arg);
             }
         }
         return unrecognizedList;
+    }
+
+    /**
+     * Returns all unrecognized parameters. This is a convenient wrapper around
+     * {@link #getUnrecognizedArguments(String, String...)} which takes in an {@code Option}
+     * array and converts it internally to a String array for comparison.
+     * @param args String to be parsed
+     * @param recognizedOptions array or variable length parameters of recognized arguments
+     * @return List of all white-space delimited arguments in {@code args} not matching
+     * those in {@code recognizedArguments}
+     */
+    public static List<String> getUnrecognizedArguments(String args, Option... recognizedOptions) {
+        requireAllNonNull(args, recognizedOptions);
+        String[] recognizedStrings = Arrays.stream(recognizedOptions).map(Option::toString)
+                .toArray(String[]::new);
+        return getUnrecognizedArguments(args, recognizedStrings);
     }
 
     /**

--- a/src/main/java/mams/logic/parser/ViewCommandParser.java
+++ b/src/main/java/mams/logic/parser/ViewCommandParser.java
@@ -26,7 +26,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_APPEAL, PREFIX_MODULE, PREFIX_STUDENT);
 
-        if (argMultimap.areAllPrefixesAbsent(PREFIX_APPEAL, PREFIX_MODULE, PREFIX_STUDENT)) {
+        if (argMultimap.areAllPrefixesAbsent(PREFIX_APPEAL, PREFIX_MODULE, PREFIX_STUDENT)
+                || !argMultimap.getPreamble().isBlank()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
@@ -44,11 +45,12 @@ public class ViewCommandParser implements Parser<ViewCommand> {
                 parameters.setStudentIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT).get()));
             }
 
+            // by this point, invalid parameters should have thrown ParseException in the earlier checks
             assert parameters.isAtLeastOneParameterPresent() : "Assertion failed: ViewCommandParameter has no params"
                     + "even after parsing";
             return new ViewCommand(parameters);
         } catch (ParseException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), e);
         }
 
     }

--- a/src/main/java/mams/ui/ResultDisplay.java
+++ b/src/main/java/mams/ui/ResultDisplay.java
@@ -28,4 +28,8 @@ public class ResultDisplay extends UiPart<Region> {
     public void clearDisplay() {
         resultDisplay.clear();
     }
+
+    public void setFocusTraversable(boolean isTraversable) {
+        resultDisplay.setFocusTraversable(isTraversable);
+    }
 }

--- a/src/main/java/mams/ui/history/HistoryListPanel.java
+++ b/src/main/java/mams/ui/history/HistoryListPanel.java
@@ -52,6 +52,7 @@ public class HistoryListPanel extends UiPart<Region> {
      */
     public void scrollToBottom() {
         int lastIndex = commandHistoryList.size() - 1;
+        itemListView.requestFocus();
         itemListView.scrollTo(lastIndex);
         itemListView.getSelectionModel().select(lastIndex);
         itemListView.getFocusModel().focus(lastIndex);

--- a/src/main/java/mams/ui/history/HistoryWindow.java
+++ b/src/main/java/mams/ui/history/HistoryWindow.java
@@ -125,6 +125,7 @@ public class HistoryWindow extends UiPart<Stage> {
      * Scroll display list to bottom.
      */
     public void scrollToBottom() {
+        historyDisplayPanelPlaceholder.requestFocus();
         historyListPanel.scrollToBottom();
     }
 

--- a/src/test/java/mams/logic/parser/HistoryCommandParserTest.java
+++ b/src/test/java/mams/logic/parser/HistoryCommandParserTest.java
@@ -1,6 +1,10 @@
 package mams.logic.parser;
 
+import static mams.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static mams.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static mams.logic.parser.HistoryCommandParser.MESSAGE_OPTIONS_NOT_RECOGNIZED;
+import static mams.logic.parser.HistoryCommandParser.OPTION_HIDE_OUTPUT;
+import static mams.logic.parser.HistoryCommandParser.OPTION_HIDE_UNSUCCESSFUL;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,15 +23,104 @@ public class HistoryCommandParserTest {
     @Test
     public void parse_hideOutput_returnsHistoryCommand() {
         assertParseSuccess(parser,
-                " " + HistoryCommandParser.OPTION_HIDE_OUTPUT.toString(),
+                " " + OPTION_HIDE_OUTPUT.toString(),
                 new HistoryCommand(true, HistoryFilterSettings.SHOW_ALL));
     }
 
     @Test
     public void parse_hideUnsuccessfulCommands_returnsHistoryCommand() {
         assertParseSuccess(parser,
-                " " + HistoryCommandParser.OPTION_HIDE_UNSUCCESSFUL.toString(),
+                " " + OPTION_HIDE_UNSUCCESSFUL.toString(),
                 new HistoryCommand(false, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+    }
+
+    @Test
+    public void parse_hideUnsuccessfulCommandsAndHideOutput_returnsHistoryCommand() {
+        assertParseSuccess(parser,
+                " " + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + OPTION_HIDE_OUTPUT.toString(),
+                new HistoryCommand(true, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+    }
+
+    /**
+     * Blankspaces should not affect parsing ability of the parser.
+     */
+    @Test
+    public void parse_validParamsWithPresenceOfBlankSpace_parseSuccessful() {
+
+        final String blankSpace = "     ";
+
+        // leading blank-space
+        assertParseSuccess(parser, blankSpace
+                + " " + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + OPTION_HIDE_OUTPUT.toString(),
+                new HistoryCommand(true, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+
+        // trailing blank-space
+        assertParseSuccess(parser, " " + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + OPTION_HIDE_OUTPUT.toString() + blankSpace,
+                new HistoryCommand(true, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+
+        // leading and trailing blank-spaces
+        assertParseSuccess(parser, blankSpace + " " + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + OPTION_HIDE_OUTPUT.toString() + blankSpace,
+                new HistoryCommand(true, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+
+        // large blank-space between arguments
+        assertParseSuccess(parser, OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + blankSpace + OPTION_HIDE_OUTPUT.toString(),
+                new HistoryCommand(true, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+
+        // sanity check: different success combination of params
+        // leading and trailing blank-space, as well as all arguments separated by large blank-spaces
+        assertParseSuccess(parser, blankSpace + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + blankSpace,
+                new HistoryCommand(false, HistoryFilterSettings.SHOW_ONLY_SUCCESSFUL));
+    }
+
+    @Test
+    public void parse_someInvalidArgumentsProvided_throwsParseException() {
+        final String invalidParam1 = "lkemfwal";
+        final String invalidParam2 = "invalid";
+
+        // all invalid parameters
+        assertParseFailure(parser,
+                invalidParam1 + " " + invalidParam2,
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, invalidParam1 + " " + invalidParam2)
+                        + "\n"
+                        + HistoryCommand.MESSAGE_USAGE);
+
+        // valid parameters but not space delimited
+        assertParseFailure(parser,
+                OPTION_HIDE_OUTPUT.toString() + OPTION_HIDE_UNSUCCESSFUL.toString(),
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, OPTION_HIDE_OUTPUT.toString()
+                        + OPTION_HIDE_UNSUCCESSFUL.toString())
+                        + "\n"
+                        + HistoryCommand.MESSAGE_USAGE);
+
+        // some valid parameters but presence of invalid parameter
+        assertParseFailure(parser,
+                OPTION_HIDE_OUTPUT.toString() + " " + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + invalidParam2,
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, invalidParam2)
+                        + "\n"
+                        + HistoryCommand.MESSAGE_USAGE);
+
+        // some valid options but presence of invalid option
+        assertParseFailure(parser,
+                OPTION_HIDE_OUTPUT.toString() + " " + OPTION_HIDE_UNSUCCESSFUL.toString()
+                        + " " + new Option(invalidParam1),
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, new Option(invalidParam1).toString())
+                        + "\n"
+                        + HistoryCommand.MESSAGE_USAGE);
+
+        // no partial matching is allowed, eg. -oinvalid should not be parsed as the valid option -o
+        assertParseFailure(parser,
+                OPTION_HIDE_OUTPUT.toString() + invalidParam2,
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, OPTION_HIDE_OUTPUT.toString()
+                        + invalidParam2)
+                        + "\n"
+                        + HistoryCommand.MESSAGE_USAGE);
     }
 
 }

--- a/src/test/java/mams/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/mams/logic/parser/ListCommandParserTest.java
@@ -1,6 +1,11 @@
 package mams.logic.parser;
 
+import static mams.logic.parser.CliSyntax.OPTION_APPEAL;
+import static mams.logic.parser.CliSyntax.OPTION_MODULE;
+import static mams.logic.parser.CliSyntax.OPTION_STUDENT;
+import static mams.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static mams.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static mams.logic.parser.ListCommandParser.MESSAGE_OPTIONS_NOT_RECOGNIZED;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,17 +32,17 @@ public class ListCommandParserTest {
     public void parse_validArgsOnlyOneParamPresent_listOneItemTypeOnly() {
         // list appeals only
         assertParseSuccess(parser,
-                " -a",
+                OPTION_APPEAL.toString(),
                 new ListCommand(true, false, false));
 
         // list modules only
         assertParseSuccess(parser,
-                " -m",
+                OPTION_MODULE.toString(),
                 new ListCommand(false, true, false));
 
         // list students only
         assertParseSuccess(parser,
-                " -s",
+                OPTION_STUDENT.toString(),
                 new ListCommand(false, false, true));
     }
 
@@ -45,32 +50,121 @@ public class ListCommandParserTest {
     public void parse_validArgsCombinationOfParams_parseSuccessful() {
         // list appeals and modules only
         assertParseSuccess(parser,
-                " -a -m ",
+                OPTION_MODULE + " " + OPTION_APPEAL,
                 new ListCommand(true, true, false));
 
         // list modules and students only
         assertParseSuccess(parser,
-                " -s -m",
+                OPTION_STUDENT + " " + OPTION_MODULE,
                 new ListCommand(false, true, true));
 
         // list students and appeals only
         assertParseSuccess(parser,
-                " -s -a",
+                OPTION_APPEAL + " " + OPTION_STUDENT,
                 new ListCommand(true, false, true));
 
         // duplicate tags, list student and appeals
         assertParseSuccess(parser,
-                " -s -a -s -a -s -a -s -a",
+                OPTION_STUDENT + " " + OPTION_STUDENT + " " + OPTION_STUDENT + " "
+                + OPTION_APPEAL + " " + OPTION_APPEAL + " " + OPTION_STUDENT,
                 new ListCommand(true, false, true));
 
         // duplicate tags, list modules
         assertParseSuccess(parser,
-                " -m -m -m -m -m -m -m -m",
+                OPTION_MODULE + " " + OPTION_MODULE + " " + OPTION_MODULE + " " + OPTION_MODULE
+                        + " " + OPTION_MODULE,
                 new ListCommand(false, true, false));
 
         // list all three items
         assertParseSuccess(parser,
-                " -s -a -m",
+                OPTION_MODULE + " " + OPTION_STUDENT + " " + OPTION_APPEAL,
                 new ListCommand(true, true, true));
+    }
+
+    /**
+     * Blankspaces should not affect parsing ability of the parser.
+     */
+    @Test
+    public void parse_validParamsWithPresenceOfBlankSpace_parseSuccessful() {
+
+        final String blankSpace = "     ";
+
+        // leading blank-space
+        assertParseSuccess(parser,
+                blankSpace + OPTION_MODULE + " " + OPTION_STUDENT + " " + OPTION_APPEAL,
+                new ListCommand(true, true, true));
+
+        // trailing blank-space
+        assertParseSuccess(parser,
+                OPTION_MODULE + " " + OPTION_STUDENT + " " + OPTION_APPEAL + blankSpace,
+                new ListCommand(true, true, true));
+
+        // leading and trailing blank-space
+        assertParseSuccess(parser,
+                blankSpace + OPTION_MODULE + " " + OPTION_STUDENT + " " + OPTION_APPEAL + blankSpace,
+                new ListCommand(true, true, true));
+
+        // large blank-space between arguments
+        assertParseSuccess(parser,
+                OPTION_MODULE + " " + blankSpace + OPTION_STUDENT + " " + OPTION_APPEAL,
+                new ListCommand(true, true, true));
+
+        // leading and trailing blank-space, as well as all arguments separated by large blank-spaces
+        assertParseSuccess(parser,
+                blankSpace + OPTION_MODULE + " " + blankSpace + OPTION_STUDENT + " " + blankSpace
+                        + OPTION_APPEAL + blankSpace,
+                new ListCommand(true, true, true));
+
+        // sanity check: different success combination of params
+        // leading and trailing blank-space, as well as all arguments separated by large blank-spaces
+        assertParseSuccess(parser,
+                blankSpace + OPTION_MODULE + " " + blankSpace + OPTION_STUDENT + " " + blankSpace,
+                new ListCommand(false, true, true));
+    }
+
+    @Test
+    public void parse_someInvalidArgumentsProvided_throwsParseException() {
+
+        final String invalidParam1 = "lkemfwal";
+        final String invalidParam2 = "invalid";
+
+        // all invalid parameters
+        assertParseFailure(parser,
+                invalidParam1 + " " + invalidParam2,
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, invalidParam1 + " " + invalidParam2)
+                        + "\n"
+                        + ListCommand.MESSAGE_USAGE);
+
+        // valid parameters but not space delimited
+        assertParseFailure(parser,
+                OPTION_APPEAL.toString() + OPTION_MODULE.toString(),
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, OPTION_APPEAL.toString()
+                        + OPTION_MODULE.toString())
+                        + "\n"
+                        + ListCommand.MESSAGE_USAGE);
+
+        // some valid parameters but presence of invalid parameter
+        assertParseFailure(parser,
+                OPTION_APPEAL.toString() + " " + OPTION_MODULE.toString()
+                        + " " + invalidParam1,
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, invalidParam1)
+                        + "\n"
+                        + ListCommand.MESSAGE_USAGE);
+
+        // some valid options but presence of invalid option
+        assertParseFailure(parser,
+                OPTION_APPEAL.toString() + " " + OPTION_MODULE.toString()
+                        + " " + new Option(invalidParam2),
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, new Option(invalidParam2))
+                        + "\n"
+                        + ListCommand.MESSAGE_USAGE);
+
+        // no partial matching is allowed, ie. -ssssss should not be parsed as the valid option -s
+        assertParseFailure(parser,
+                OPTION_STUDENT.toString() + invalidParam2,
+                String.format(MESSAGE_OPTIONS_NOT_RECOGNIZED, OPTION_STUDENT.toString()
+                        + invalidParam2)
+                        + "\n"
+                        + ListCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/mams/logic/parser/OptionsTokenizerTest.java
+++ b/src/test/java/mams/logic/parser/OptionsTokenizerTest.java
@@ -81,5 +81,13 @@ public class OptionsTokenizerTest {
         Collections.sort(output);
         Collections.sort(unrecognizedArguments);
         assertEquals(output, unrecognizedArguments);
+
+        // test overloaded version that accepts {@code Options[]}
+        output = OptionsTokenizer.getUnrecognizedArguments(argsString,
+                option1,
+                option2);
+        Collections.sort(output);
+        Collections.sort(unrecognizedArguments);
+        assertEquals(output, unrecognizedArguments);
     }
 }

--- a/src/test/java/mams/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/mams/logic/parser/ViewCommandParserTest.java
@@ -125,6 +125,25 @@ public class ViewCommandParserTest {
     }
 
     @Test
+    void parse_unnecessaryPreamblePresent_throwParseException() {
+
+        // valid format but unnecessary preamble present
+        assertParseFailure(parser,
+                " preamble s/1 m/5",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+
+        // invalid format and unnecessary preamble present
+        assertParseFailure(parser,
+                " preamble s/alfkaflkan m/5",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+
+        // unnecessary preamble present and no prefixes present
+        assertParseFailure(parser,
+                " preamble",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     void parse_allIndexesSpecifiedValid_parseSuccess() {
 
         ViewCommand.ViewCommandParameters params = new ViewCommand.ViewCommandParameters();


### PR DESCRIPTION
- Edit `UserGuide.adoc` to provide a file tree structure of the expected `data/` placement
- Fix HistoryWindow to force a re-focus on listView element after re-opening or re-focusing the window via the `history` command
- Updated `list` and `history` to reject all unnecessary and invalid parameters instead of ignoring them, as per team standardisation.
  - added tests for such cases.